### PR TITLE
try to fix the node stack error

### DIFF
--- a/R/telemetry.R
+++ b/R/telemetry.R
@@ -21,10 +21,11 @@ subset.telemetry <- function(x,...)
 
 get.telemetry <- function(data,axes=c("x","y"))
 {
-  z <- "[.data.frame"(data,axes)
-  z <- as.matrix(z)
-  colnames(z) <- axes
-  return(z)
+  # z <- "[.data.frame"(data,axes)
+  # z <- as.matrix(z)
+  # colnames(z) <- axes
+  # return(z)
+  temp <- as.matrix(data.frame(data)[, axes], dimnames = axes)
 }
 
 #######################

--- a/R/telemetry.R
+++ b/R/telemetry.R
@@ -25,7 +25,7 @@ get.telemetry <- function(data,axes=c("x","y"))
   # z <- as.matrix(z)
   # colnames(z) <- axes
   # return(z)
-  temp <- as.matrix(data.frame(data)[, axes], dimnames = axes)
+  return(as.matrix(data.frame(data)[, axes], dimnames = axes))
 }
 
 #######################


### PR DESCRIPTION
# problem
issue #5 , error in example of `variogram.fit.html`

```
#Load package and data
library(ctmm)
data(buffalo)

#Extract movement data for a single animal
cilla <- buffalo[[1]]

#Calculate variogram
SVF <- variogram(cilla)
#> Error in `[.data.frame`(x, ...): node stack overflow

# generate a visual fit of the variogram (requires RStudio)
variogram.fit(SVF)
#> Error in variogram.fit(SVF): object 'SVF' not found
```

## error cause
[line 24](https://github.com/ctmm-initiative/ctmm/compare/master...ctmm-initiative:xhdong-nodestack#diff-6c56485c67ff7b526f19f3fb99e7bf6bL24)

I'm not quite sure how the original code works. I guess the purpose is to get the data frame part of data, then pick columns x, y. My code have same result in simple test, verified by `identical(z, temp)`. 

I don't know why the original code failed sometime but works in many time, and if my code will have same result in all cases. Just this fixed the error without need of restart R session. And in building references there are lots of examples running, it will be impossible to restart R session before every example.