### PR TITLE
decompress zip to temp file for fread

### DIFF
--- a/R/telemetry.R
+++ b/R/telemetry.R
@@ -212,11 +212,13 @@ as.telemetry.data.frame <- function(object,timeformat="",timezone="UTC",projecti
 as.telemetry.character <- function(object,timeformat="",timezone="UTC",projection=NULL,UERE=NULL,...)
 {
   # fread doesn't work on compressed files yet
-  data <- try(data.table::fread(object,data.table=FALSE,check.names=TRUE,nrows=5),silent=TRUE)
-  # if fread fails, then fall back on read.table
+  # using tryCatch because sometimes the fread error message for reading zip file have characters cannot be displayed in system locale, and there will be warning for that.
+  # currently the error message is lost, we can use print(e) for debugging.
+  data <- tryCatch(data.table::fread(object,data.table=FALSE,check.names=TRUE,nrows=5), 
+                   error = function(e) "error")
+  # if fread fails, then decompress zip to temp file, read data, remove temp file
   if (class(data) == "data.frame") { data <- data.table::fread(object,data.table=FALSE,check.names=TRUE,...) }
-  else { data <- utils::read.csv(object,...) }
-  
+  else { data <- temp_unzip(object, data.table::fread, data.table=FALSE,check.names=TRUE,...) }
   data <- as.telemetry.data.frame(data,timeformat=timeformat,timezone=timezone,projection=projection,UERE=UERE)
   return(data)
 }

--- a/R/temp_unzip.R
+++ b/R/temp_unzip.R
@@ -1,0 +1,40 @@
+# To decompress zip, gz, bzip2, xz into temp file, run function then remove temp file.
+# more detail in https://gist.github.com/xhdong-umd/6429e7f96735142fa467f3b1daa91a2c
+temp_unzip <- function(filename, fun, ...){
+  BFR.SIZE <- 1e7
+  if (!file.exists(filename)) {
+    stop("No such file: ", filename);
+  }
+  if (!is.function(fun)) {
+    stop(sprintf("Argument 'fun' is not a function: %s", mode(fun)));
+  }
+  temp_dir <- tempdir()
+  # test if it's zip
+  f_in_zip <- try(unzip(filename, list = TRUE)$Name[1], silent = TRUE)
+  if (class(f_in_zip) == "character") {
+    unzip(filename, exdir = temp_dir, overwrite = TRUE)
+    dest_file <- file.path(temp_dir, f_in_zip)
+  } else {
+    # always overwrite this file. The file could be other than csv but we don't care since it is not supposed to visible to user
+    dest_file <- file.path(tempdir(), "temp_unzipped.csv")
+    # Setup input and output connections
+    inn <- gzfile(filename, open = "rb")
+    out <- file(description = dest_file, open = "wb")
+    # Process
+    nbytes <- 0
+    repeat {
+      bfr <- readBin(inn, what=raw(0L), size=1L, n=BFR.SIZE)
+      n <- length(bfr)
+      if (n == 0L) break;
+      nbytes <- nbytes + n
+      writeBin(bfr, con=out, size=1L)
+      bfr <- NULL  # Not needed anymore
+    }
+    close(inn)
+    close(out)
+  }
+  # call fun with temp file
+  res <- fun(dest_file, ...)
+  file.remove(dest_file)
+  return(res)
+}

--- a/R/temp_unzip.R
+++ b/R/temp_unzip.R
@@ -15,8 +15,7 @@ temp_unzip <- function(filename, fun, ...){
     unzip(filename, exdir = temp_dir, overwrite = TRUE)
     dest_file <- file.path(temp_dir, f_in_zip)
   } else {
-    # always overwrite this file. The file could be other than csv but we don't care since it is not supposed to visible to user
-    dest_file <- file.path(tempdir(), "temp_unzipped.csv")
+    dest_file <- tempfile()
     # Setup input and output connections
     inn <- gzfile(filename, open = "rb")
     out <- file(description = dest_file, open = "wb")


### PR DESCRIPTION
This is still about #2 

Last time I already have some code to decompress zip to temp folder then read with `fread`, just I didn't hanlde all the formats. Upon reading source code of `R.utils` I found it's not too hard to use R builtin connections to decompress zip into files.

So `temp_unzip` here will take zip, bzip2, xz, gz and decompress to temp folder, run some function then delete the temp file.

I put more details about this function in [this gist](https://gist.github.com/xhdong-umd/6429e7f96735142fa467f3b1daa91a2c). Compare to reading uncompressed 160M csv file, using `temp_unzip` only take very slightly longer time(2.4s vs 2.1s).

The changes to `as.temeletry` is simple, though I found there are some warnings about some characters were not valid for my system locale when I tested with `leroy.csv.gz` in `move`. It looks like when `fread` read binary file and failed, the warning message have some characters from the binary file which was not suppressed fully with `silent = TRUE`. Interestingly this warning didn't appear with our first version with `fread` on Feb.23, but only appear with current build. 

I used `tryCatch` to suppress that warning since it's not really useful. If we ever had some problem and need to check the error message, we can change `error = function(e) "error"` into `error = function(e) print(e)`, or even just use `try()`.