### PR TITLE
data.table new version throw warning instead of error when reading zip

### DIFF
--- a/R/telemetry.R
+++ b/R/telemetry.R
@@ -148,7 +148,8 @@ as.telemetry.character <- function(object,timeformat="",timezone="UTC",projectio
   data <- tryCatch(data.table::fread(object,data.table=FALSE,check.names=TRUE,nrows=5),
                    error = function(e) "error")
   # if fread fails, then decompress zip to temp file, read data, remove temp file
-  if (class(data) == "data.frame") { data <- data.table::fread(object,data.table=FALSE,check.names=TRUE,...) }
+  # previous data.table will generate error when reading zip, now it's warning and result is an empty data.frame.
+  if (class(data) == "data.frame" && nrow(data) > 0) { data <- data.table::fread(object,data.table=FALSE,check.names=TRUE,...) }
   else {
     data <- tryCatch(temp_unzip(object, data.table::fread, data.table=FALSE,check.names=TRUE,...),
                      error = function(e) "error")


### PR DESCRIPTION
I found the newer version of `data.table` changed behavior when using `fread` on a zip. 

Previously it will throw error, now it will generate warning but still return an empty data.frame. Thus the error condition check need to be updated to reflect the change. The change should also work with previous version of data.table.